### PR TITLE
Bug1194767 - prefer slugid.nice() over slugid.v4()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Example below how for to create two dependent tasks:
 var queue = new taskcluster.Queue(...);
 
 // Create two taskIds
-var taskIdA = slugid.v4();
-var taskIdB = slugid.v4();
+var taskIdA = slugid.nice();
+var taskIdB = slugid.nice();
 
 // Define taskA (which is scheduled by taskcluster-scheduler)
 queue.defineTask(taskIdA, {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-TaskCluster Task Scheduler
-==========================
+TaskCluster Task Scheduler (Prototype)
+======================================
 
 This is a simple scheduler that schedules dependent tasks. This is done by
 listening for all task-defined messages, load tasks and read the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-TaskCluster Task Scheduler (Prototype)
-======================================
+TaskCluster Task Scheduler
+==========================
 
 This is a simple scheduler that schedules dependent tasks. This is done by
 listening for all task-defined messages, load tasks and read the


### PR DESCRIPTION
@jonasfj Please note, I didn't update the tests currently using `slugid.v4()` to use `slugid.nice()` since we should still support regular v4 slugs, which are a superset of "nice" slugs. Therefore existing tests cover both cases.

This change is to documentation only, to recommend the use of "nice" slugids.
